### PR TITLE
Add Event Building tutorial, update LogData to work with Moku:Go

### DIFF
--- a/tutorials/daq/event_building.ipynb
+++ b/tutorials/daq/event_building.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "097f6fb7-2d37-473c-823e-a950c2273976",
+   "metadata": {},
+   "source": [
+    "# Event Building from HDF5 Files\n",
+    "-----\n",
+    "In this example notebook, we will show how to carry out random and threshold triggering on a continuous stream of data, with data acquired via the Moku."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e36e14b4-3fcc-4a07-a550-460d269bf3b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import splendsp as sp\n",
+    "import splendaq as sq"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f90ca5d-bd7c-491b-952e-d3e83f86a5b2",
+   "metadata": {},
+   "source": [
+    "We will first generate some continuous pulse data with the Moku. See the `logging_data.ipynb` tutorial for further explanation on how to log data, as this notebook is for offline triggering after the data has been logged.\n",
+    "\n",
+    "The setup we are assuming here is that Output1 one of the Moku is directly connected to Input1, sending square pulses as a rate of 10 Hz for 30 s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f068887e-b0cc-46de-a5f4-390c49bbe378",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = 1.25e6\n",
+    "with LogData(moku_ip, fs=fs) as LOG:\n",
+    "    LOG.set_input_channels(1)\n",
+    "    pulse_settings = LOG.pulse_settings(\n",
+    "        amplitude=0.1,\n",
+    "        frequency=10,\n",
+    "        offset=0,\n",
+    "        edge_time=50e-6,\n",
+    "        pulse_width=1e-3,\n",
+    "    )\n",
+    "    LOG.set_output_channel(1, 'Pulse', **pulse_settings)\n",
+    "\n",
+    "    LOG.log_data(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc32ec3e-0db7-427e-9b07-047b8600c064",
+   "metadata": {},
+   "source": [
+    "We now have a 30 second long file of continuous data, which will we need to convert to a `splendaq` HDF5 file for compatibility with the continuous data acquisition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93925e49-50b9-4ee8-a22c-7f80e8a6e37b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sq.io.convert_li_to_h5('your_file.li', my_os='mac')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbdb24c3-e44a-4ba9-b9a9-c2a9ac18a6e2",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Initalizing the Event Builder\n",
+    "\n",
+    "The event building functionality assumes a specific organization of the data, which is as follows:\n",
+    "\n",
+    "All continuous data to be triggered on is placed in one folder, in this case a folder called `continuous/`. The user should create a folder for the event building algorithm to save the triggered events (both randomly triggered and threshold triggered). In this example, we assume there is a folder called `trigger`.\n",
+    "\n",
+    "Before acquiring any pulses, we initialize the `EventBuilder` class with these folders. During this, the user must specify how long (in bins) the saved traces should be. The user may optionally specify up to how many traces per dump should be saved before a new dump is created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8be1c246-01bc-4858-9572-2b9febac72a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EB = sq.daq.EventBuilder(\n",
+    "    './continuous/',\n",
+    "    './trigger/',\n",
+    "    10000, # traces will be 10000 bins long\n",
+    "    # maxevtsperdump=500, # default value to keep individual files relatively small\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "416a4b2d-e16f-4d99-bae2-b6c4fe8b4233",
+   "metadata": {},
+   "source": [
+    "## Acquiring Random Triggers\n",
+    "\n",
+    "The random triggering algorithm will look at all the total size of all of the continuous data files and randomly choose nonoverlapping sections from the files to save as \"randoms\". In this way, the randoms will encompass the entire dataset. The user must specify how many randoms should be saved, we'll acquire 500 randoms in this example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36d2787c-a260-4a50-af4b-1c16c7e2ebe7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EB_rands.acquire_randoms(500) # acquire 500 randoms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a59c32a6-d1f1-4436-a568-50960a1fcec6",
+   "metadata": {},
+   "source": [
+    "## Threshold Triggering\n",
+    "\n",
+    "To trigger on some specified threshold, we use the so-called optimal filter formalism, which can quickly be described as a matched filter that takes into account the known noise environment. This is generally written in terms of the minimization of the below $\\chi^2$\n",
+    "$$\\chi^2 = \\int_{-\\infty}^\\infty \\mathop{\\mathrm{d}f} \\frac{|\\tilde{v}(f) - A \\mathrm{e}^{i \\omega t} \\tilde{s}(f)|^2}{J(f)},$$\n",
+    "where $\\tilde{v}(f)$ is the Fourier transform of some signal with noise, $\\tilde{s}(f)$ is some known template of the true signal (usually normalized to a height of unity), $A$ is the height estimate of the signal, $t$ is the start time of that signal, and $J(f)$ is the power spectral density (PSD) (i.e. the description of the noise environment in frequency space).\n",
+    "\n",
+    "In this formalism, the expected baseline amplitude resolution $\\sigma_A$ can be calculated, and we will set our eventual threshold based on the number of $\\sigma_A$. Before doing that, let's define a template and a PSD to use for threshold triggering.\n",
+    "\n",
+    "### Define template\n",
+    "\n",
+    "Our template should be the expected shape of our signal. In this case, we have a square wave of width 1 ms, so we will create that template, normalized to a height of unity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94ea1ec1-7a6f-4b78-8635-b89b2562d905",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "template = np.zeros(10000)\n",
+    "nbins = int(1e-3 * fs)\n",
+    "template[len(template)//2:len(template)//2 + nbins] = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7139a068-1ee3-4646-a12f-abfc4abe39f0",
+   "metadata": {},
+   "source": [
+    "Note, sometimes the expected signal is not known a priori. In this case, one could instead average many of the measured signals, and then use that as a template (after normalizing to a height of unity).\n",
+    "\n",
+    "### Calculate PSD\n",
+    "\n",
+    "With our template defined, we next want to measure the PSD. To do this, we will open all of our randoms, remove those with pulses, and then use the remaining randoms to calculate the PSD. In these steps, we will use the SPLENDOR DSP package, `splendsp`, which can be installed via `pip`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cb4145a-4349-4b43-9cbf-9112882e9483",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FR = sq.io.Reader('./trigger/randoms_file.h5')\n",
+    "randoms = FR.get_data()\n",
+    "\n",
+    "# IterCut is a class for iteratively marking events as \"bad\" based on some criteria\n",
+    "IC = sp.IterCut(randoms[:, 0], fs, plotall=False)\n",
+    "IC.pileupcut(template=template, cut=2)\n",
+    "IC.baselinecut(cut=2)\n",
+    "\n",
+    "f, psd_no_cuts = sp.calc_psd(randoms[:, 0], fs=fs, folded_over=False)\n",
+    "f, psd = sp.calc_psd(randoms[IC.cmask, 0], fs=fs, folded_over=False)\n",
+    "\n",
+    "# let's plot the PSD with and without the cuts, to show the difference\n",
+    "plt.loglog(f, sp.calc_psd(randoms[:, 0], fs=fs)[1]**0.5)\n",
+    "plt.loglog(f, sp.calc_psd(randoms[IC.cmask, 1], fs=fs)[1]**0.5)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f49a123-be67-49e5-b77f-fbd5ec101a56",
+   "metadata": {},
+   "source": [
+    "### Run the Threshold Trigger\n",
+    "\n",
+    "Now that we have our template and PSD, we can now run the threshold trigger. To do this, we use the `acquire_pulses` method, passing the template, psd, a threshold (in units of number of $\\sigma$), and which channel to trigger on. In this case, we will set an $8\\sigma$ trigger on the channel we took data on (we only logged one channel, so this is the only option anyways).\n",
+    "\n",
+    "Note that, when a signal has a height near the threshold (defined as threshold > measured signal height / e), then the turn off threshold is that measured signal height / e, rather than threshold. This is to avoid marking events that are near threshold as multiple triggers due to fluctuations above and below the threshold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd11e174-da5a-4de2-8cd5-d874e8b451d6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "EB.acquire_pulses(\n",
+    "    template,\n",
+    "    psd,\n",
+    "    8, # 8-sigma threshold\n",
+    "    0, # trigger on channel index 0\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1426e3e5-9959-490a-831a-40f09064498e",
+   "metadata": {},
+   "source": [
+    "We have now acquired both random and threshold triggered events, which can then be read via `splendaq.io.Reader`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "987062d2-3a88-421a-b540-89349d9ba6dd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/daq/event_building.ipynb
+++ b/tutorials/daq/event_building.ipynb
@@ -41,15 +41,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fs = 1.25e6\n",
-    "with LogData(moku_ip, fs=fs) as LOG:\n",
+    "fs = 500e3\n",
+    "moku_ip = 'your_moku_ip'\n",
+    "\n",
+    "pulse_width = 1e-3\n",
+    "edge_time = 50e-6\n",
+    "\n",
+    "with sq.daq.LogData(moku_ip, fs=fs, force_connect=True) as LOG:\n",
     "    LOG.set_input_channels(1)\n",
     "    pulse_settings = LOG.pulse_settings(\n",
-    "        amplitude=0.1,\n",
+    "        amplitude=0.2,\n",
     "        frequency=10,\n",
     "        offset=0,\n",
-    "        edge_time=50e-6,\n",
-    "        pulse_width=1e-3,\n",
+    "        edge_time=edge_time,\n",
+    "        pulse_width=pulse_width,\n",
     "    )\n",
     "    LOG.set_output_channel(1, 'Pulse', **pulse_settings)\n",
     "\n",
@@ -71,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sq.io.convert_li_to_h5('your_file.li', my_os='mac')"
+    "sq.io.convert_li_to_h5('your_logged_file.li', my_os='mac')"
    ]
   },
   {
@@ -97,10 +102,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "nbins_trace = 10000 # traces will be 10000 bins long\n",
+    "\n",
     "EB = sq.daq.EventBuilder(\n",
     "    './continuous/',\n",
     "    './trigger/',\n",
-    "    10000, # traces will be 10000 bins long\n",
+    "    nbins_trace,\n",
     "    # maxevtsperdump=500, # default value to keep individual files relatively small\n",
     ")"
    ]
@@ -122,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "EB_rands.acquire_randoms(500) # acquire 500 randoms"
+    "EB.acquire_randoms(500) # acquire 500 randoms"
    ]
   },
   {
@@ -140,7 +147,7 @@
     "\n",
     "### Define template\n",
     "\n",
-    "Our template should be the expected shape of our signal. In this case, we have a square wave of width 1 ms, so we will create that template, normalized to a height of unity."
+    "Our template should be the expected shape of our signal. In this case, we have a trapezoidal pulse of width 1 ms and edge times of 50 us, so we will create that template, normalized to a height of unity."
    ]
   },
   {
@@ -150,9 +157,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "template = np.zeros(10000)\n",
-    "nbins = int(1e-3 * fs)\n",
-    "template[len(template)//2:len(template)//2 + nbins] = 1"
+    "template = np.zeros(nbins_trace)\n",
+    "nbins_edge = int(edge_time * fs)\n",
+    "nbins_flat = int((pulse_width - edge_time) * fs) # note the pulse width is distance between the half way points of the edge times\n",
+    "template[\n",
+    "    len(template)//2:len(template)//2 + nbins_edge\n",
+    "] = np.arange(nbins_edge) / nbins_edge\n",
+    "template[\n",
+    "    len(template)//2 + nbins_edge:len(template)//2 + nbins_edge + nbins_flat\n",
+    "] = 1\n",
+    "template[\n",
+    "    len(template)//2 + nbins_edge + nbins_flat:len(template)//2 + 2 * nbins_edge + nbins_flat\n",
+    "] = np.arange(nbins_edge)[::-1] / nbins_edge"
    ]
   },
   {
@@ -179,16 +195,20 @@
     "\n",
     "# IterCut is a class for iteratively marking events as \"bad\" based on some criteria\n",
     "IC = sp.IterCut(randoms[:, 0], fs, plotall=False)\n",
-    "IC.pileupcut(template=template, cut=2)\n",
-    "IC.baselinecut(cut=2)\n",
+    "IC.pileupcut(template=template, cut=1.5)\n",
     "\n",
-    "f, psd_no_cuts = sp.calc_psd(randoms[:, 0], fs=fs, folded_over=False)\n",
     "f, psd = sp.calc_psd(randoms[IC.cmask, 0], fs=fs, folded_over=False)\n",
     "\n",
-    "# let's plot the PSD with and without the cuts, to show the difference\n",
-    "plt.loglog(f, sp.calc_psd(randoms[:, 0], fs=fs)[1]**0.5)\n",
-    "plt.loglog(f, sp.calc_psd(randoms[IC.cmask, 1], fs=fs)[1]**0.5)\n",
-    "\n"
+    "# let's plot the folded over square root of PSD with and without the cuts, to show the difference\n",
+    "f_fold, psd_no_cuts_fold = sp.calc_psd(randoms[:, 0], fs=fs, folded_over=True)\n",
+    "f_fold, psd_fold = sp.calc_psd(randoms[IC.cmask, 0], fs=fs, folded_over=True)\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.loglog(f_fold, psd_no_cuts_fold**0.5, color='r', label=\"Before Cuts\")\n",
+    "ax.loglog(f_fold, psd_fold**0.5, color='b', label=\"After Cuts\")\n",
+    "ax.set_ylabel(\"NEP [V/$\\sqrt{\\mathrm{Hz}}$]\")\n",
+    "ax.set_xlabel(\"Frequency [Hz]\")\n",
+    "ax.legend(edgecolor='k', framealpha=1)"
    ]
   },
   {
@@ -215,7 +235,7 @@
     "EB.acquire_pulses(\n",
     "    template,\n",
     "    psd,\n",
-    "    8, # 8-sigma threshold\n",
+    "    20, # 20-sigma threshold\n",
     "    0, # trigger on channel index 0\n",
     ")"
    ]
@@ -232,6 +252,41 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "987062d2-3a88-421a-b540-89349d9ba6dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FR = sq.io.Reader()\n",
+    "triggered_pulses, metadata = FR.get_data('trigger/triggered_file.h5', include_metadata=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a3f8cad-6e11-4cc3-9146-9a0d50802559",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(triggered_pulses[0,0] - np.mean(triggered_pulses[0,0, :4000]), color='k', label=\"Triggered Data\")\n",
+    "ax.plot(metadata['triggeramp'][0] * template, color='r', linestyle='dashed', label=\"Fit Template\")\n",
+    "ax.set_ylabel(\"NEP [V/$\\sqrt{\\mathrm{Hz}}$]\")\n",
+    "ax.set_xlabel(\"Frequency [Hz]\")\n",
+    "ax.set_xlim(4900, 5800)\n",
+    "ax.legend(edgecolor='k', framealpha=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fc398f3-171e-4705-a597-85eedb817853",
+   "metadata": {},
+   "source": [
+    "And we can see that we have reconstructed the amplitude very well!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d0d3e62-1bfa-4f27-b8cf-7c83de4ce7ba",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
This PR adds an Event Building tutorial for logging continuous data, acquiring randoms, and applying an offline trigger. Also in this PR, I added the functionality needed to have LogData be compatible with the Moku:Go (as it was only compatible with the Moku:Pro before).