### PR TITLE
Disable all channels after exiting the Moku

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     numpy
     scipy
     matplotlib
-    moku>=2.5
+    moku>=2.6.2
     h5py
     pyyaml
 python_requires = >=3.6

--- a/src/splendaq/daq/_log_data.py
+++ b/src/splendaq/daq/_log_data.py
@@ -60,7 +60,9 @@ class LogData(object):
 
         """
 
-        self.DL = Datalogger(ip_address, force_connect=force_connect)
+        self.DL = Datalogger(
+            ip_address, force_connect=force_connect, session_trust_env=False,
+        )
         self.DL.set_acquisition_mode(acquisition_mode)
         self._max_dur_per_file = max_duration_per_file
 
@@ -83,7 +85,21 @@ class LogData(object):
         return self
 
     def __exit__(self, type, value, traceback):
-        """Always run relinquish ownership when exiting."""
+        """
+        Always run relinquish ownership and turn off inputs and outputs
+        when exiting.
+
+        """
+
+        if self._device == "Moku:Pro":
+            chan_list = [1, 2, 3, 4]
+        elif self._device == "Moku:Go":
+            chan_list = [1, 2]
+
+        for chan in chan_list:
+            self.DL.generate_waveform(chan, 'Off') # disable outputs
+            self.DL.disable_channel(chan) # disable inputs
+
         self.DL.relinquish_ownership()
 
     def set_input_channels(self, channels, impedance="1MOhm", coupling="DC",


### PR DESCRIPTION
In this PR, I've added the automated shut off of each input and output on the `LogData` and `Oscilloscope` context managers upon exiting.

I also defaulted to ignoring the macOS automatic proxies, which can prevent users from connecting to the Moku via IPv4 or IPv6 if there are default workplace proxy settings.