### PR TITLE
Update log_data to actually use the specified max duration per file

### DIFF
--- a/src/splendaq/daq/_log_data.py
+++ b/src/splendaq/daq/_log_data.py
@@ -454,8 +454,13 @@ class LogData(object):
         nfiles = np.int32(np.ceil(duration / self._max_dur_per_file))
 
         for ii in range(nfiles):
+            if (ii + 1) * self._max_dur_per_file > duration:
+                this_file_duration = duration % self._max_dur_per_file
+            else:
+                this_file_duration = self._max_dur_per_file
+
             logfile = self.DL.start_logging(
-                duration=duration,
+                duration=this_file_duration,
                 comments=comments,
                 file_name_prefix=file_name_prefix,
             )


### PR DESCRIPTION
In `log_data`, the specified maximum duration per file was ignored, resulting in much more data being taken than desired. This fix respects that parameter, where each file will either be the specified maximum duration, or the remaining specified time if the last chunk is less than the max duration set.

Fixes #9.