### PR TITLE
Add `mergewindow` kwarg to `EventBuilder.acquire_pulses`

### DIFF
--- a/tutorials/daq/event_building.ipynb
+++ b/tutorials/daq/event_building.ipynb
@@ -237,6 +237,7 @@
     "    psd,\n",
     "    20, # 20-sigma threshold\n",
     "    0, # trigger on channel index 0\n",
+    "    mergewindow=None, # save all triggered events, set to a positive integer to merge events that are within this window\n",
     ")"
    ]
   },


### PR DESCRIPTION
In this PR, I've added an option to merge triggered events that are within a specified window (i.e. number of time bins). This can be helpful to lower data rates, and not save triggers that are due to ringing from large pulses in certain situations.