### PR TITLE
Add Moku:Lab Support

### DIFF
--- a/src/splendaq/daq/_log_data.py
+++ b/src/splendaq/daq/_log_data.py
@@ -498,9 +498,16 @@ class LogData(object):
 
             filenames.append(logfile['file_name'])
 
+        if self._device == "Moku:Pro":
+            target = "ssd"
+        elif self._device == "Moku:Lab":
+            target = "media"
+        elif self._device == "Moku:Go":
+            target = "persist"
+
         for fname in filenames:
             self.DL.download(
-                "ssd" if self._device == "Moku:Pro" else "persist",
+                target,
                 fname,
                 os.path.abspath(savepath + os.sep + fname),
             )

--- a/src/splendaq/daq/_log_data.py
+++ b/src/splendaq/daq/_log_data.py
@@ -42,11 +42,13 @@ class LogData(object):
             allowed values are 10 to 10e6 Hz for the Moku:Pro for 1
             channel logging, where the max decreases to 5e6 Hz for 2
             channel logging and to 1.25e6 for 3 or 4 channel logging.
-            The allowed values are 10 to 1e6 Hz for 1 channel logging,
-            wheere the maximum allowed value decreases to 500e3 Hz for
-            2 channel logging. Default is the lowest allowed maximum
-            value for the given device (i.e. 1.25e6 for Moku:Pro and
-            500e3 for Moku:Go).
+            For the Moku:Lab, the allowed values are 10 to 2.5e5 Hz.
+            For the Moku:Go, the allowed values are 10 to 1e6 Hz for
+            1 channel logging, where the maximum allowed value
+            decreases to 500e3 Hz for 2 channel logging. Default is the
+            lowest allowed maximum value for the given device (i.e.
+            1.25e6 for Moku:Pro, 2.5e5 for Moku:Lab, and 500e3 for
+            Moku:Go).
         max_duration_per_file : float, optional
             The maximum amount of seconds to save to a single file.
             Avoids creating very large single files. Default is 60
@@ -67,14 +69,16 @@ class LogData(object):
         self._max_dur_per_file = max_duration_per_file
 
         self._device = self.DL.describe()['hardware']
-        if self._device not in ['Moku:Pro', 'Moku:Go']:
+        if self._device not in ['Moku:Pro', 'Moku:Lab', 'Moku:Go']:
             raise ValueError(
-                "Unrecognized device, is not a Moku:Go or Moku:Pro."
+                "Unrecognized device, is not a Moku:Go, Moku:Lab, or Moku:Pro."
             )
 
         if fs is None:
             if self._device == "Moku:Pro":
                 self._fs = 1.25e6
+            elif self._device == "Moku:Lab":
+                self._fs = 2.5e5
             elif self._device == "Moku:Go":
                 self._fs = 500e3
         else:
@@ -93,7 +97,7 @@ class LogData(object):
 
         if self._device == "Moku:Pro":
             chan_list = [1, 2, 3, 4]
-        elif self._device == "Moku:Go":
+        elif self._device in ["Moku:Lab", "Moku:Go"]:
             chan_list = [1, 2]
 
         for chan in chan_list:
@@ -113,13 +117,13 @@ class LogData(object):
             Which input channels to log data from. Can be a single
             value for one channel, or a list of the channels. For the
             Moku:Pro, valid channel numbers are 1, 2, 3, and 4. For the
-            Moku:Go, valid channel numbers are 1 and 2.
+            Moku:Lab and Moku:Go, valid channel numbers are 1 and 2.
         impedance : str, list of str, optional
             The output impedance to use for each channel. For the
-            Moku:Pro, options are '1MOhm' and '50Ohm'. For the Moku:Go,
-            the only option is '1MOhm'. Can pass a list of the same
-            length as channels if different impedances are desired for
-            a Moku:Pro. Default is '1MOhm' for all channels.
+            Moku:Pro and Moku:Lab, options are '1MOhm' and '50Ohm'. For
+            the Moku:Go, the only option is '1MOhm'. Can pass a list of
+            the same length as channels if different impedances are
+            desired for a Moku:Pro. Default is '1MOhm' for all channels.
         coupling : str, list of str, optional
             The coupling to use for each channel. Options are 'DC' and
             'AC'. Can pass a list of the same length as channels if
@@ -128,18 +132,22 @@ class LogData(object):
         vrange : str, list of str, optional
             The voltage range to use for each channel. For the
             Moku:Pro, options are '400mVpp', '4Vpp' and '40Vpp'. For
-            the Moku:Go, options are '10Vpp' and '50Vpp'. Can pass a
-            list of the same length as channels if different voltage
-            ranges are desired for specific channels. Default is the
-            smallest allowed value for the device for all channels
-            (i.e. '400mVpp' for the Moku:Pro and '10Vpp' for the
-            Moku:Go).
+            the Moku:Lab, the options are '1Vpp' and '10Vpp'. For the
+            Moku:Go, options are '10Vpp' and '50Vpp'. Can pass a list
+            of the same length as channels if different voltage ranges
+            are desired for specific channels. Default is the smallest
+            allowed value for the device for all channels (i.e.
+            '400mVpp' for the Moku:Pro, '1Vpp' for the Moku:Lab, and
+            '10Vpp' for the Moku:Go).
 
         """
 
         if self._device == "Moku:Pro":
             chan_list = [1, 2, 3, 4]
             vrange = '400mVpp' if vrange is None else vrange
+        elif self._device == "Moku:Lab":
+            chan_list = [1, 2]
+            vrange = '1Vpp' if vrange is None else vrange
         elif self._device == "Moku:Go":
             chan_list = [1, 2]
             vrange = '10Vpp' if vrange is None else vrange
@@ -176,25 +184,27 @@ class LogData(object):
         Parameters
         ----------
         amplitude : float, optional
-             Waveform peak-to-peak amplitude in Volts. Allowed values
-             are 2e-3 to 10 for the Moku:Go and 1e-3 to 10 for the
-             Moku:Pro (For Moku:Pro, the output voltage is limited to
-             between -1V and 1V above 1MHz). Default is 1 V.
+            Waveform peak-to-peak amplitude in Volts. Allowed values
+            are 2e-3 to 10 for the Moku:Go, 2e-3 to 4 for the
+            Moku:Lab, and 1e-3 to 10 for the Moku:Pro (For Moku:Pro,
+            the output voltage is limited to between -1V and 1V above
+            1MHz). Default is 1 V.
         frequency : float, optional
-             Waveform frequency in Hz. Allowed values are 1e-3 to 20e6
-             for the Moku:Go and 1e-3 to 500e6 for the Moku:Pro.
-             Default is 10000 Hz.
+            Waveform frequency in Hz. Allowed values are 1e-3 to 20e6
+            for the Moku:Go, 1e-3 to 100e6 for the Moku:Lab, and 1e-3
+            to 500e6 for the Moku:Pro. Default is 10000 (1e4) Hz.
         offset : float, optional
-             DC offset applied to the waveform in V. Allowed values are
-             -5 to 5 for Moku:Go and Moku:Pro (For Moku:Pro, the output
-             voltage is limited to between -1V and 1V above 1MHz).
-             Default is 0.
+            DC offset applied to the waveform in V. Allowed values are
+            -5 to 5 for Moku:Go, Moku:Lab, and Moku:Pro (For Moku:Pro,
+            the output voltage is limited to between -1V and 1V above
+            1MHz). Default is 0.
         phase : float, optional
             Waveform phase offset in degrees. Allowed values are 0 to
-            360 for Moku:Go and Moku:Pro. Default is 0.
+            360 for Moku:Go, Moku:Lab, and Moku:Pro. Default is 0.
         symmetry : float, optional
             Fraction of the cycle rising in %. Allowed values are 0.0
-            to 100.0 for Moku:Go and Moku:Pro. Default is 50.
+            to 100.0 for Moku:Go, Moku:Lab, and Moku:Pro. Default is
+            50.
 
         Returns
         -------
@@ -220,28 +230,30 @@ class LogData(object):
         Parameters
         ----------
         amplitude : float, optional
-             Waveform peak-to-peak amplitude in Volts. Allowed values
-             are 2e-3 to 10 for the Moku:Go and 1e-3 to 10 for the
-             Moku:Pro (For Moku:Pro, the output voltage is limited to
-             between -1V and 1V above 1MHz). Default is 1 V.
+            Waveform peak-to-peak amplitude in Volts. Allowed values
+            are 2e-3 to 10 for the Moku:Go, 2e-3 to 4 for the
+            Moku:Lab, and 1e-3 to 10 for the Moku:Pro (For Moku:Pro,
+            the output voltage is limited to between -1V and 1V above
+            1MHz). Default is 1 V.
         frequency : float, optional
-             Waveform frequency in Hz. Allowed values are 1e-3 to 20e6
-             for the Moku:Go and 1e-3 to 500e6 for the Moku:Pro.
-             Default is 10000 Hz.
+            Waveform frequency in Hz. Allowed values are 1e-3 to 20e6
+            for the Moku:Go, 1e-3 to 100e6 for the Moku:Lab, and 1e-3
+            to 500e6 for the Moku:Pro. Default is 10000 (1e4) Hz.
         offset : float, optional
-             DC offset applied to the waveform in V. Allowed values are
-             -5 to 5 for Moku:Go and Moku:Pro (For Moku:Pro, the output
-             voltage is limited to between -1V and 1V above 1MHz).
-             Default is 0.
+            DC offset applied to the waveform in V. Allowed values are
+            -5 to 5 for Moku:Go, Moku:Lab, and Moku:Pro (For Moku:Pro,
+            the output voltage is limited to between -1V and 1V above
+            1MHz). Default is 0.
         phase : float, optional
             Waveform phase offset in degrees. Allowed values are 0 to
-            360 for Moku:Go and Moku:Pro. Default is 0.
+            360 for Moku:Go, Moku:Lab, and Moku:Pro. Default is 0.
         duty : float, optional
             Duty cycle as percentage in %. Allowed values are 0 to 100
             for Moku:Go and Moku:Pro. Default is 0.
         symmetry : float, optional
             Fraction of the cycle rising in %. Allowed values are 0.0
-            to 100.0 for Moku:Go and Moku:Pro. Default is 50.
+            to 100.0 for Moku:Go, Moku:Lab, and Moku:Pro. Default is
+            50.
 
         Returns
         -------
@@ -270,25 +282,27 @@ class LogData(object):
         Parameters
         ----------
         amplitude : float, optional
-             Waveform peak-to-peak amplitude in Volts. Allowed values
-             are 2e-3 to 10 for the Moku:Go and 1e-3 to 10 for the
-             Moku:Pro (For Moku:Pro, the output voltage is limited to
-             between -1V and 1V above 1MHz). Default is 1 V.
+            Waveform peak-to-peak amplitude in Volts. Allowed values
+            are 2e-3 to 10 for the Moku:Go, 2e-3 to 4 for the
+            Moku:Lab, and 1e-3 to 10 for the Moku:Pro (For Moku:Pro,
+            the output voltage is limited to between -1V and 1V above
+            1MHz). Default is 1 V.
         frequency : float, optional
-             Waveform frequency in Hz. Allowed values are 1e-3 to 20e6
-             for the Moku:Go and 1e-3 to 500e6 for the Moku:Pro.
-             Default is 10000 Hz.
+            Waveform frequency in Hz. Allowed values are 1e-3 to 20e6
+            for the Moku:Go, 1e-3 to 100e6 for the Moku:Lab, and 1e-3
+            to 500e6 for the Moku:Pro. Default is 10000 (1e4) Hz.
         offset : float, optional
-             DC offset applied to the waveform in V. Allowed values are
-             -5 to 5 for Moku:Go and Moku:Pro (For Moku:Pro, the output
-             voltage is limited to between -1V and 1V above 1MHz).
-             Default is 0.
+            DC offset applied to the waveform in V. Allowed values are
+            -5 to 5 for Moku:Go, Moku:Lab, and Moku:Pro (For Moku:Pro,
+            the output voltage is limited to between -1V and 1V above
+            1MHz). Default is 0.
         phase : float, optional
             Waveform phase offset in degrees. Allowed values are 0 to
-            360 for Moku:Go and Moku:Pro. Default is 0.
+            360 for Moku:Go, Moku:Lab, and Moku:Pro. Default is 0.
         symmetry : float, optional
             Fraction of the cycle rising in %. Allowed values are 0.0
-            to 100.0 for Moku:Go and Moku:Pro. Default is 50.
+            to 100.0 for Moku:Go, Moku:Lab, and Moku:Pro. Default is
+            50.
 
         Returns
         -------
@@ -316,34 +330,38 @@ class LogData(object):
         Parameters
         ----------
         amplitude : float, optional
-             Waveform peak-to-peak amplitude in Volts. Allowed values
-             are 2e-3 to 10 for the Moku:Go and 1e-3 to 10 for the
-             Moku:Pro (For Moku:Pro, the output voltage is limited to
-             between -1V and 1V above 1MHz). Default is 1 V.
+            Waveform peak-to-peak amplitude in Volts. Allowed values
+            are 2e-3 to 10 for the Moku:Go, 2e-3 to 4 for the
+            Moku:Lab, and 1e-3 to 10 for the Moku:Pro (For Moku:Pro,
+            the output voltage is limited to between -1V and 1V above
+            1MHz). Default is 1 V.
         frequency : float, optional
-             Waveform frequency in Hz. Allowed values are 1e-3 to 20e6
-             for the Moku:Go and 1e-3 to 500e6 for the Moku:Pro.
-             Default is 10000 Hz.
+            Waveform frequency in Hz. Allowed values are 1e-3 to 20e6
+            for the Moku:Go, 1e-3 to 100e6 for the Moku:Lab, and 1e-3
+            to 500e6 for the Moku:Pro. Default is 10000 (1e4) Hz.
         offset : float, optional
-             DC offset applied to the waveform in V. Allowed values are
-             -5 to 5 for Moku:Go and Moku:Pro (For Moku:Pro, the output
-             voltage is limited to between -1V and 1V above 1MHz).
-             Default is 0.
+            DC offset applied to the waveform in V. Allowed values are
+            -5 to 5 for Moku:Go, Moku:Lab, and Moku:Pro (For Moku:Pro,
+            the output voltage is limited to between -1V and 1V above
+            1MHz). Default is 0.
         phase : float, optional
             Waveform phase offset in degrees. Allowed values are 0 to
-            360 for Moku:Go and Moku:Pro. Default is 0.
+            360 for Moku:Go, Moku:Lab, and Moku:Pro. Default is 0.
         symmetry : float, optional
             Fraction of the cycle rising in %. Allowed values are 0.0
-            to 100.0 for Moku:Go and Moku:Pro. Default is 50.
+            to 100.0 for Moku:Go, Moku:Lab, and Moku:Pro. Default is
+            50.
         edge_time : float, optional
             Edge-time of the waveform in s. Allowed values are 16e-9 to
-            pulse_width for the Moku:Go and 2e-9 to pulse_width for the
-            Moku:Pro. Default is 0 (i.e. the shortest time).
+            pulse_width for the Moku:Go, 4e-9 to pulse_width for the
+            Moku:Lab, and 2e-9 to pulse_width for the Moku:Pro. Default
+            is 0 (which sets it to the shortest allowed time).
         pulse_width : float, optional
             Pulse width of the waveform in s. Allowed values are 16e-9
-            to waveform period for the Moku:Go and 2e-9 to waveform
-            period for the Moku:Pro. Default is 0 (i.e. ths shortest
-            time).
+            to waveform period for the Moku:Go, 4e-9 to waveform period
+            for the Moku:Lab and 2e-9 to waveform period for the
+            Moku:Pro. Default is 0 (which sets it to the shortest
+            allowed time).
 
         Returns
         -------
@@ -400,22 +418,23 @@ class LogData(object):
         channel : int
             The output channel to generate a waveform on. With a
             Moku:Pro, this must be an integer of 1, 2, 3 or 4. With a
-            Moku:Go, this must be an integer of 1 or 2.
+            Moku:Go or Moku:Lab, this must be an integer of 1 or 2.
         waveformtype : str
             The waveform type to generate, must be one of 'Sine',
             'Square', 'Ramp', 'Pulse', 'DC'. Can also be set to 'Off'
             to turn the channel off.
         load : str, optional
             The load impedance to use for the output channel. For a
-            Moku:Pro, this must be one of '1MOhm' or '50Ohm'. For a
-            Moku:Go, this can only be '1MOhm'. Default is '1MOhm'.
+            Moku:Pro or Moku:Lab, this must be one of '1MOhm' or
+            '50Ohm'. For a Moku:Go, this can only be '1MOhm'. Default
+            is '1MOhm'.
         settings : dict
             The dictionary containing all of the settings needed for
             the specified waveform type.
 
         """
 
-        if self._device == "Moku:Pro":
+        if self._device in ["Moku:Pro", "Moku:Lab"]:
             self.DL.set_output_load(channel, load)
         self.DL.generate_waveform(
             channel,

--- a/src/splendaq/daq/_oscilloscope.py
+++ b/src/splendaq/daq/_oscilloscope.py
@@ -51,9 +51,9 @@ class Oscilloscope(object):
         self.Osc.set_acquisition_mode(acquisition_mode)
 
         self._device = self.Osc.describe()['hardware']
-        if self._device not in ['Moku:Pro', 'Moku:Go']:
+        if self._device not in ['Moku:Pro', 'Moku:Lab', 'Moku:Go']:
             raise ValueError(
-                "Unrecognized device, is not a Moku:Go or Moku:Pro."
+                "Unrecognized device, is not a Moku:Go, Moku:Lab, or Moku:Pro."
             )
 
     def __enter__(self):
@@ -69,7 +69,7 @@ class Oscilloscope(object):
 
         if self._device == "Moku:Pro":
             chan_list = [1, 2, 3, 4]
-        elif self._device == "Moku:Go":
+        elif self._device in ["Moku:Lab", "Moku:Go"]:
             chan_list = [1, 2]
 
         for chan in chan_list:
@@ -89,13 +89,13 @@ class Oscilloscope(object):
             Which input channels to log data from. Can be a single
             value for one channel, or a list of the channels. For the
             Moku:Pro, valid channel numbers are 1, 2, 3, and 4. For the
-            Moku:Go, valid channel numbers are 1 and 2.
+            Moku:Lab and Moku:Go, valid channel numbers are 1 and 2.
         impedance : str, list of str, optional
             The output impedance to use for each channel. For the
-            Moku:Pro, options are '1MOhm' and '50Ohm'. For the Moku:Go,
-            the only option is '1MOhm'. Can pass a list of the same
-            length as channels if different impedances are desired for
-            a Moku:Pro. Default is '1MOhm' for all channels.
+            Moku:Pro and Moku:Lab, options are '1MOhm' and '50Ohm'. For
+            the Moku:Go, the only option is '1MOhm'. Can pass a list of
+            the same length as channels if different impedances are
+            desired for a Moku:Pro. Default is '1MOhm' for all channels.
         coupling : str, list of str, optional
             The coupling to use for each channel. Options are 'DC' and
             'AC'. Can pass a list of the same length as channels if
@@ -104,18 +104,22 @@ class Oscilloscope(object):
         vrange : str, list of str, optional
             The voltage range to use for each channel. For the
             Moku:Pro, options are '400mVpp', '4Vpp' and '40Vpp'. For
-            the Moku:Go, options are '10Vpp' and '50Vpp'. Can pass a
-            list of the same length as channels if different voltage
-            ranges are desired for specific channels. Default is the
-            smallest allowed value for the device for all channels
-            (i.e. '400mVpp' for the Moku:Pro and '10Vpp' for the
-            Moku:Go).
+            the Moku:Lab, the options are '1Vpp' and '10Vpp'. For the
+            Moku:Go, options are '10Vpp' and '50Vpp'. Can pass a list
+            of the same length as channels if different voltage ranges
+            are desired for specific channels. Default is the smallest
+            allowed value for the device for all channels (i.e.
+            '400mVpp' for the Moku:Pro, '1Vpp' for the Moku:Lab, and
+            '10Vpp' for the Moku:Go).
 
         """
 
         if self._device == "Moku:Pro":
             chan_list = [1, 2, 3, 4]
             vrange = '400mVpp' if vrange is None else vrange
+        elif self._device == "Moku:Lab":
+            chan_list = [1, 2]
+            vrange = '1Vpp' if vrange is None else vrange
         elif self._device == "Moku:Go":
             chan_list = [1, 2]
             vrange = '10Vpp' if vrange is None else vrange
@@ -155,15 +159,16 @@ class Oscilloscope(object):
         channel : int, list of int
             The output channel to generate a waveform on. With a
             Moku:Pro, this must be an integer of 1, 2, 3 or 4. With a
-            Moku:Go, this must be an integer of 1 or 2.
+            Moku:Lab or Moku:Go, this must be an integer of 1 or 2.
         waveformtype : str, list of str, optional
             The waveform type to generate, only supports 'DC' waveforms
             at the moment. Can also be set to 'Off' to turn the channel
             off. Default is 'DC'.
         load : str, list of str, optional
             The load impedance to use for the output channel. For a
-            Moku:Pro, this must be one of '1MOhm' or '50Ohm'. For a
-            Moku:Go, this can only be '1MOhm'. Default is '1MOhm'.
+            Moku:Pro or Moku:Lab, this must be one of '1MOhm' or
+            '50Ohm'. For a Moku:Go, this can only be '1MOhm'. Default
+            is '1MOhm'.
         dc_level : float, list of float, optional
             The dictionary containing all of the settings needed for
             the specified waveform type. Default is 0.
@@ -180,7 +185,7 @@ class Oscilloscope(object):
             dc_level = [dc_level] * len(channels)
 
         for ind, chan in enumerate(channels):
-            if self._device == "Moku:Pro":
+            if self._device in ["Moku:Pro", "Moku:Lab"]:
                 self.Osc.set_output_load(chan, load[ind])
             self.Osc.generate_waveform(
                 channel=chan,
@@ -198,9 +203,9 @@ class Oscilloscope(object):
         sources : str, list of str
             The sources which to read out in order of increasing
             channel number. Can be some combination of "Input1",
-            "Input2", "Output1", "Output2" for the Moku:Go, with
-            "Input3", "Input4", "Output3", and "Output4" also available
-            for the Moku:Pro.
+            "Input2", "Output1", "Output2" for the Moku:Go or Moku:Lab,
+            with "Input3", "Input4", "Output3", and "Output4" also
+            available for the Moku:Pro.
         duration : float
             The total time in seconds to collect data with the current
             configuration.
@@ -224,4 +229,3 @@ class Oscilloscope(object):
         data = self.Osc.get_data()
 
         return data
-

--- a/src/splendaq/daq/_oscilloscope.py
+++ b/src/splendaq/daq/_oscilloscope.py
@@ -170,8 +170,8 @@ class Oscilloscope(object):
             '50Ohm'. For a Moku:Go, this can only be '1MOhm'. Default
             is '1MOhm'.
         dc_level : float, list of float, optional
-            The dictionary containing all of the settings needed for
-            the specified waveform type. Default is 0.
+            The DC level of the output of the channel in V. Default is
+            0.
 
         """
 


### PR DESCRIPTION
With Moku:Lab now updated to work with the `moku` Python API, I've added the ability to use Moku:Lab in the various data logging functionality that we have.