### PR TITLE
Change turn-off threshold to be based on number of sigma

### DIFF
--- a/tutorials/daq/event_building.ipynb
+++ b/tutorials/daq/event_building.ipynb
@@ -218,9 +218,11 @@
    "source": [
     "### Run the Threshold Trigger\n",
     "\n",
-    "Now that we have our template and PSD, we can now run the threshold trigger. To do this, we use the `acquire_pulses` method, passing the template, psd, a threshold (in units of number of $\\sigma$), and which channel to trigger on. In this case, we will set an $20\\sigma$ trigger on the channel we took data on (we only logged one channel, so this is the only option anyways).\n",
+    "Now that we have our template and PSD, we can now run the threshold trigger. To do this, we use the `acquire_pulses` method, passing the template, psd, a turn-on (or activation) threshold (in units of number of $\\sigma$), and which channel to trigger on. In this case, we will set an $20\\sigma$ trigger on the channel we took data on (we only logged one channel, so this is the only option anyways).\n",
     "\n",
-    "Note that, when a signal has a height near the threshold (defined as threshold > measured signal height / e), then the turn off threshold is that measured signal height / e, rather than threshold. This is to avoid marking events that are near threshold as multiple triggers due to fluctuations above and below the threshold."
+    "Note that, when a section of the signal is near the threshold, then there may be fluctuations about the turn-on threshold that could be marked erroneously as separate events. To avoid this, we have a turn-off threshold that defaults to turn-on threshold minus 2, rather than the turn-on threshold, thus the filtered signal must drop below, in this example, $18\\sigma$ to end the region of the data that is marked as single event.\n",
+    "\n",
+    "The turn-off threshold may also be specified by the user. At low turn-on thresholds (below $5\\sigma$), the turn-off threshold defaults to $3\\sigma$. If the turn-on threshold is below $3\\sigma$, then the turn-off threshold defaults to the turn-on threshold."
    ]
   },
   {
@@ -237,6 +239,7 @@
     "    psd,\n",
     "    20, # 20-sigma threshold\n",
     "    0, # trigger on channel index 0\n",
+    "    threshold_off=None, # defaults to threshold_on - 2, i.e. threshold_off = 20 - 2 = 18\n",
     "    mergewindow=None, # save all triggered events, set to a positive integer to merge events that are within this window\n",
     ")"
    ]


### PR DESCRIPTION
When a section of the signal is near the threshold, then there may be fluctuations about the turn-on threshold that could be marked erroneously as separate events. Before this commit, the turn-off threshold used was the smaller or $A_{\mathrm{max}}/e$ and the threshold specified by the user. However, this method was still vulnerable to noise fluctuations near the turn-on threshold in certain cases. To remedy this, we changed it so that the turn-off threshold defaults to turn-on threshold minus 2 in most cases (other cases detailed below), in order to reject fluctuations about threshold as new events ~95% of the time.

The turn-off threshold may also be specified by the user. At low turn-on thresholds (below $5\\sigma$), the turn-off threshold defaults to $3\\sigma$. If the turn-on threshold is below $3\\sigma$, then the turn-off threshold defaults to the turn-on threshold."