### PR TITLE
Fix deprecation warning by no longer using disable channel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     numpy
     scipy
     matplotlib
-    moku>=3.0.0
+    moku>=3.2.0
     h5py
     pyyaml
     pyserial

--- a/src/splendaq/daq/_log_data.py
+++ b/src/splendaq/daq/_log_data.py
@@ -101,6 +101,7 @@ class LogData(object):
             chan_list = [1, 2]
 
         for chan in chan_list:
+            self.DL.enable_input(chan, False) # disable inputs
             self.DL.generate_waveform(chan, 'Off') # disable outputs
 
         self.DL.relinquish_ownership()
@@ -162,8 +163,9 @@ class LogData(object):
 
         disable_chans = [chan not in channels for chan in chan_list]
         for chan, disable in zip(chan_list, disable_chans):
-            if not disable:
-                self.DL.enable_input(chan)
+            if disable:
+                self.DL.enable_input(chan, False)
+            else:
                 ind = channels.index(chan)
                 self.DL.set_frontend(
                     channel=chan,
@@ -403,7 +405,7 @@ class LogData(object):
             'dc_level': dc_level,
         }
 
-    def set_output_channel(self, channel, waveformtype, load="1MOhm",
+    def set_output_channel(self, channel, waveformtype, load="HiZ",
                            **settings):
         """
         Method to turn on an output channel and generate the speicified
@@ -421,11 +423,11 @@ class LogData(object):
             The waveform type to generate, must be one of 'Sine',
             'Square', 'Ramp', 'Pulse', 'DC'. Can also be set to 'Off'
             to turn the channel off.
-        load : str, optional
-            The load impedance to use for the output channel. For a
-            Moku:Pro or Moku:Lab, this must be one of '1MOhm' or
-            '50Ohm'. For a Moku:Go, this can only be '1MOhm'. Default
-            is '1MOhm'.
+        termination : str, optional
+            The waveform termination to use for the output channel.
+            For a Moku:Pro or Moku:Lab, this must be one of 'HiZ' or
+            '50Ohm'. For a Moku:Go, this can only be 'HiZ'. Default
+            is 'HiZ'.
         settings : dict
             The dictionary containing all of the settings needed for
             the specified waveform type.
@@ -433,7 +435,7 @@ class LogData(object):
         """
 
         if self._device in ["Moku:Pro", "Moku:Lab"]:
-            self.DL.set_output_load(channel, load)
+            self.DL.set_output_termination(channel, load)
         self.DL.generate_waveform(
             channel,
             waveformtype,
@@ -487,12 +489,9 @@ class LogData(object):
                 # Wait for the logging session to progress by sleeping 0.5sec
                 time.sleep(0.5)
                 # Get current progress percentage and check if it's complete
-                try:
-                    progress = self.DL.logging_progress()
-                    remaining_time = progress['time_remaining']
-                    is_logging = remaining_time >= 0
-                except:
-                    is_logging = False
+                progress = self.DL.logging_progress()
+                remaining_time = progress['time_remaining']
+                is_logging = remaining_time > 0
 
             filenames.append(logfile['file_name'])
 

--- a/src/splendaq/daq/_log_data.py
+++ b/src/splendaq/daq/_log_data.py
@@ -102,7 +102,6 @@ class LogData(object):
 
         for chan in chan_list:
             self.DL.generate_waveform(chan, 'Off') # disable outputs
-            self.DL.disable_channel(chan) # disable inputs
 
         self.DL.relinquish_ownership()
 
@@ -163,9 +162,8 @@ class LogData(object):
 
         disable_chans = [chan not in channels for chan in chan_list]
         for chan, disable in zip(chan_list, disable_chans):
-            if disable:
-                self.DL.disable_channel(chan)
-            else:
+            if not disable:
+                self.DL.enable_channel(chan)
                 ind = channels.index(chan)
                 self.DL.set_frontend(
                     channel=chan,

--- a/src/splendaq/daq/_log_data.py
+++ b/src/splendaq/daq/_log_data.py
@@ -163,7 +163,7 @@ class LogData(object):
         disable_chans = [chan not in channels for chan in chan_list]
         for chan, disable in zip(chan_list, disable_chans):
             if not disable:
-                self.DL.enable_channel(chan)
+                self.DL.enable_input(chan)
                 ind = channels.index(chan)
                 self.DL.set_frontend(
                     channel=chan,


### PR DESCRIPTION
Fixes the deprecation warning that comes with using `disable_channel` instead of `enable_input`. Requires `moku>=3.2.0`. Closes #16.

Also fixed the logging data getting stuck due to a new definition of the time remaining being sent by the moku