### PR TITLE
Fix negative pulse triggering

### DIFF
--- a/src/splendaq/daq/_offline_trigger.py
+++ b/src/splendaq/daq/_offline_trigger.py
@@ -518,20 +518,18 @@ class EventBuilder(object):
 
             for kk, filt in enumerate(filtered):
 
-                if posthreshold:
-                    ranges = EventBuilder._smart_trigger(
-                        filt, self._threshold_on, self._threshold_off, mergewindow,
-                    )
-                else:
-                    ranges = EventBuilder._smart_trigger(
-                        -filt, -self._threshold_on, -self._threshold_off, mergewindow,
-                    )
+                ranges = EventBuilder._smart_trigger(
+                    sign * filt,
+                    sign * self._threshold_on,
+                    sign * self._threshold_off,
+                    mergewindow,
+                )
 
                 if len(ranges)==0:
                     break
 
                 for ind0, ind1 in zip(ranges[:, 0], ranges[:, 1]):
-                    indmax = ind0 + np.argmax(filt[ind0:ind1])
+                    indmax = ind0 + np.argmax(sign * filt[ind0:ind1])
                     evtinds_list.append([indmax - self._tracelength//2])
                     triginds_list.append([indmax])
                     evtamps_list.append([filt[indmax]])


### PR DESCRIPTION
When applying a threshold that is negative, the code would still try to find the highest positive value (rather than the largest negative going value). This fix simplifies the code and correctly applies the sign fixed by the inputted threshold.